### PR TITLE
Better handling of PATH variable when master and slaves are not using the same platform

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/customtools/CustomTool.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/customtools/CustomTool.java
@@ -34,6 +34,7 @@ import hudson.tools.ZipExtractionInstaller;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -135,19 +136,21 @@ public class CustomTool extends ToolInstallation implements
                 FileSet fs = Util.createFileSet(new File(getHome()),exportedPaths);
                 DirectoryScanner ds = fs.getDirectoryScanner();
 
-                return ds.getIncludedDirectories();
+                String[] pathsFound = ds.getIncludedDirectories();
+
+                List<String> completePaths = new ArrayList<String>();
+                for (String dir : pathsFound) {
+                    completePaths.add(new File(getHome(), dir).getAbsolutePath());
+                }
+
+                // be extra greedy in case they added "./. or . or ./"
+                completePaths.add(getHome());
+
+                return completePaths.toArray(new String[completePaths.size()]);
             };
         });
-        
-        List<String> completePaths = new ArrayList<String>();
-        for (String dir : pathsFound) {
-            completePaths.add(new File(getHome(), dir).getAbsolutePath());
-        }
-        
-        // be extra greedy in case they added "./. or . or ./"
-        completePaths.add(getHome());
-        
-        return completePaths;
+
+        return Arrays.asList(pathsFound);
     }
 
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/customtools/CustomToolInstallWrapper.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/customtools/CustomToolInstallWrapper.java
@@ -128,12 +128,18 @@ public class CustomToolInstallWrapper extends BuildWrapper {
         return new DecoratedLauncher(launcher) {            
             @Override
             public Proc launch(ProcStarter starter) throws IOException {
-                EnvVars vars = toEnvVars(starter.envs());
-                
-                for (String path : paths) {
-                    vars.override("PATH+", path);
+                String[] envs;
+                try {
+                    envs = starter.envs();
+                } catch (final NullPointerException ex) {
+                    envs = new String[0];
                 }
-                vars.putAll(homes);
+                final EnvVars vars = toEnvVars(envs);
+
+                for (int i = 0; i < paths.size(); i++) {
+                    vars.put("PATH+" + i, paths.get(i));
+                }
+                
                 return super.launch(starter.envs(Util.mapToEnv(vars)));
             }
 


### PR DESCRIPTION
PATH variable separators were generated on the master, causing wrong separators to be used when slave and master were not on the same platform. For a Linux master and a Windows slave, / was used instead of \ and : instead of ;

Also catch an NPE on recent jenkins version (at least 1.503). I don't see how to do this better. 
