### PR TITLE
[FIXED JENKINS-20560] - Custom-tools should not override global paths in...

### DIFF
--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/customtools/PathsList.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/customtools/PathsList.java
@@ -86,8 +86,16 @@ public class PathsList implements Serializable {
         return this.paths.addAll(pathsList.paths);
     }
     
+    /**
+     * Gets the list of installed tools
+     * @return A list with valid delimiters or null if paths is empty
+     */
     public String toListString() {
-        StringBuilder builder = new StringBuilder(paths.size()*2);
+        if (paths.isEmpty()) {
+            return null;
+        }
+        
+        StringBuilder builder = new StringBuilder();
         for ( String path : paths) {         
             builder.append(path);
             builder.append(pathSeparator);

--- a/src/test/java/com/cloudbees/jenkins/plugins/customtools/CustomToolInstallWrapperTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/customtools/CustomToolInstallWrapperTest.java
@@ -58,6 +58,8 @@ public class CustomToolInstallWrapperTest extends HudsonTestCase {
         nestedWrapperTestImpl(wrappers, true);
     }
     
+    
+    
     /**
      * Tests custom tools with wrapper, which calls wrapper without
      * specifying of envs.
@@ -68,6 +70,14 @@ public class CustomToolInstallWrapperTest extends HudsonTestCase {
         List<BuildWrapper> wrappers = new ArrayList<BuildWrapper>(2);
         wrappers.add(new CommandCallerInstaller());  
         wrappers.add(setupCustomToolsWrapper());     
+        nestedWrapperTestImpl(wrappers, false);
+    }
+    
+    //@Bug(20560)
+    public void testEmptyToolsList() throws Exception {
+        List<BuildWrapper> wrappers = new ArrayList<BuildWrapper>(0); 
+        wrappers.add(new CommandCallerInstaller());
+        wrappers.add(new CustomToolInstallWrapper(null, MulticonfigWrapperOptions.DEFAULT, false));
         nestedWrapperTestImpl(wrappers, false);
     }
     


### PR DESCRIPTION
...side nested launchers

I've also refactored retrieval of paths list.
Related to: https://issues.jenkins-ci.org/browse/JENKINS-20560

Signed-off-by: Oleg Nenashev nenashev@synopsys.com
