### PR TITLE
[FIXED JENKINS-24113] - Added a helper to escape property file substitutions

### DIFF
--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/customtools/LabelSpecifics.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/customtools/LabelSpecifics.java
@@ -26,6 +26,7 @@ import java.io.Serializable;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
+import jenkins.plugins.customtools.util.envvars.VariablesSubstitutionHelper;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -77,17 +78,19 @@ public class LabelSpecifics extends AbstractDescribableImpl<LabelSpecifics> impl
         return l == null || l.contains(node);
     }
     
-    public @Nonnull LabelSpecifics substitute(EnvVars vars) {
-        return new LabelSpecifics(label, vars.expand(additionalVars), vars.expand(exportedPaths));
-    }
-    
-    public @Nonnull LabelSpecifics substitute(Node node) {
+    public @Nonnull LabelSpecifics substitute(@Nonnull EnvVars vars) {
         return new LabelSpecifics(label, 
-                EnvStringParseHelper.resolveExportedPath(additionalVars, node), 
-                EnvStringParseHelper.resolveExportedPath(exportedPaths, node));
+                VariablesSubstitutionHelper.PROP_FILE.resolveVariable(additionalVars, vars),
+                VariablesSubstitutionHelper.PATH.resolveVariable(exportedPaths, vars));
     }
     
-    public static @Nonnull LabelSpecifics[] substitute (LabelSpecifics[] specifics, EnvVars vars) {
+    public @Nonnull LabelSpecifics substitute(@Nonnull Node node) {
+        return new LabelSpecifics(label, 
+                VariablesSubstitutionHelper.PROP_FILE.resolveVariable(additionalVars, node),
+                VariablesSubstitutionHelper.PATH.resolveVariable(exportedPaths, node));
+    }
+    
+    public static @Nonnull LabelSpecifics[] substitute (LabelSpecifics[] specifics, @Nonnull EnvVars vars) {
         LabelSpecifics[] out = new LabelSpecifics[specifics.length];
         for (int i=0; i<specifics.length; i++) {
             out[i] = specifics[i].substitute(vars);

--- a/src/main/java/jenkins/plugins/customtools/util/envvars/VariablesSubstitutionHelper.java
+++ b/src/main/java/jenkins/plugins/customtools/util/envvars/VariablesSubstitutionHelper.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2014 Oleg Nenashev <o.v.nenashev@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jenkins.plugins.customtools.util.envvars;
+
+import hudson.EnvVars;
+import hudson.model.Hudson;
+import hudson.model.Node;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
+import hudson.slaves.NodeProperty;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.Properties;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+/**
+ * Substitutes variables.
+ * @since TODO
+ * @author Oleg Nenashev <o.v.nenashev@gmail.com>
+ */
+public abstract class VariablesSubstitutionHelper {
+    
+    public static final VariablesSubstitutionHelper PROP_FILE = new PropFileVariablesSubstitutionHelper();
+    public static final VariablesSubstitutionHelper PATH = new SimpleVariablesSubstitutionHelper();
+    
+    /**
+     * Escapes variable values for the required format.
+     * @param variableName Name of the variable, which is being substituted
+     * @param rawValue Input value
+     * @return Escaped value
+     */
+    public String escapeVariableValue(String variableName, String rawValue) {       
+        return rawValue;
+    }
+    
+    /**
+     * Resolves tools installation directory using global variables.
+     * @param environment Collection of environment variables
+     * @param inputValue Input path with macro calls
+     * @return Raw string
+     * @since 0.3
+     */
+    public String resolveVariable(@CheckForNull String inputValue, @Nonnull EnvVars environment)  {
+        if (inputValue == null || !hasMacros(inputValue)) 
+            return inputValue;    
+        
+        // Substitute parameters      
+        String substitutedString = inputValue;
+        for (Map.Entry<String,String> entry : environment.entrySet()) {
+            if (hasMacros(inputValue, entry.getKey())) {
+                final String escapedValue = escapeVariableValue(entry.getKey(), entry.getValue());
+                substitutedString = substitutedString.replace("${" + entry.getKey() + "}", escapedValue);
+            }
+        }
+             
+        return substitutedString;     
+    }
+    
+    public String resolveVariable(@CheckForNull String inputValue, @Nonnull Node node) {
+        if (!hasMacros(inputValue)) 
+            return inputValue;
+        
+        // Check node properties
+        String substitutedString = inputValue;
+        for (NodeProperty<?> entry : node.getNodeProperties()) {
+            substitutedString = substituteNodeProperty(substitutedString, entry);
+        }    
+        
+        // Substitute global variables
+        for (NodeProperty<?> entry : Hudson.getInstance().getGlobalNodeProperties()) {
+            substitutedString = substituteNodeProperty(substitutedString, entry);
+        } 
+        
+        return substitutedString;
+    }  
+    
+    /**
+     * Substitutes string according to node property.
+     * @param macroString String to be substituted
+     * @param property Node property
+     * @return Substituted string
+     * @since 0.3
+     */
+    private String substituteNodeProperty(@CheckForNull String macroString, @CheckForNull NodeProperty<?> property) {
+        // Get environment variables
+        if (property != null && property instanceof EnvironmentVariablesNodeProperty) {
+           EnvironmentVariablesNodeProperty prop = (EnvironmentVariablesNodeProperty)property;
+           return resolveVariable(macroString, prop.getEnvVars());
+        }
+        
+        //TODO: add support of other configuration entries or propagate environments
+        return macroString;
+    }
+    
+    public static boolean hasMacros(@CheckForNull String inputString) {
+        return inputString != null ? inputString.contains("${") : false;
+    }
+    
+    public static boolean hasMacros(@CheckForNull String inputString, String macroName) {
+        return inputString != null ? inputString.contains("${"+macroName+"}") : false;
+    }
+    
+    public static class SimpleVariablesSubstitutionHelper extends VariablesSubstitutionHelper {
+        
+    }
+    
+    public static class PropFileVariablesSubstitutionHelper extends VariablesSubstitutionHelper {
+
+        @Override
+        public String escapeVariableValue(String variableName, String rawValue) {
+            OutputStream str= new ByteArrayOutputStream();
+            Properties prop = new Properties();
+            prop.setProperty("TMP", rawValue);
+            try {
+                prop.store(str,"tmp");
+            } catch (IOException ex) {
+                // Fallback to the default behavior
+                //TODO: Really???
+                return super.escapeVariableValue(variableName, rawValue);
+            }
+            
+            String res = str.toString().split("\n")[2].replaceFirst(".*TMP=", "").trim();
+            return res;
+        }       
+    }
+}


### PR DESCRIPTION
The commit introduces a Helper class, which is able to substitute variables for paths and property files.
Additional parsers can be added on-demand.

Signed-off-by: Oleg Nenashev o.v.nenashev@gmail.com
