### PR TITLE
[FIXED JENKINS-14515] Incorrect path separator used on Win slave from Unix master

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/customtools/CustomToolInstallWrapper.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/customtools/CustomToolInstallWrapper.java
@@ -228,6 +228,8 @@ public class CustomToolInstallWrapper extends BuildWrapper {
                     vars = toEnvVars(starter.envs());
                 } catch (NullPointerException npe) {
                     vars = new EnvVars();
+                } catch (InterruptedException x) {
+                    throw new IOException(x);
                 }
                  
                 // Inject paths
@@ -253,8 +255,8 @@ public class CustomToolInstallWrapper extends BuildWrapper {
                 return getInner().launch(starter.envs(vars));
             }
                         
-            private EnvVars toEnvVars(String[] envs) {
-                EnvVars vars = new EnvVars();
+            private EnvVars toEnvVars(String[] envs) throws IOException, InterruptedException {
+                EnvVars vars = node.toComputer().getEnvironment();
                 for (String line : envs) {
                     vars.addLine(line);
                 }


### PR DESCRIPTION
[JENKINS-14515](https://issues.jenkins-ci.org/browse/JENKINS-14515). Unfortunately I have no idea how to write an automated test for this, since the bug only occurs when the slave is a different platform from the master.
