### PR TITLE
Fixing <scm>

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,9 @@
   </licenses>
 
   <scm>
-    <connection>scm:git:ssh://github.com/jenkinsci/customtoosl-plugin.git</connection>
-    <developerConnection>scm:git:ssh://git@github.com/jenkinsci/customtools-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/customtools-plugin</url>
+    <connection>scm:git:git://github.com/jenkinsci/custom-tools-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/custom-tools-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/custom-tools-plugin</url>
     <tag>HEAD</tag>
   </scm>
 


### PR DESCRIPTION
Cf. https://github.com/jenkinsci/plugin-compat-tester/pull/60#issuecomment-356035256

* Fixing a typo, and a missing `-`.
* Normalizing to [this style](https://github.com/jenkinsci/archetypes/blob/d6599c5efcf3b14a35d38bbcb3d5147dc8ffaee6/empty-plugin/src/main/resources/archetype-resources/pom.xml#L27-L28) of URL.

@reviewbybees esp. @oleg-nenashev