### PR TITLE
Cleanup formatting in Jelly files

### DIFF
--- a/src/main/resources/com/cloudbees/jenkins/plugins/customtools/CustomTool/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/customtools/CustomTool/config.jelly
@@ -22,33 +22,34 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <st:documentation>
-    
-  </st:documentation>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:entry title="${%Name}" field="name">
     <f:textbox/>
   </f:entry>
   <f:advanced title="${%Custom Tool Configuration}" align="left">
-      <f:entry title="${%Exported paths}" field="exportedPaths">
-          <f:textbox/>
-      </f:entry>
-      <f:entry title="${%Installation directory}" field="home">
-          <f:textbox/>
-      </f:entry>
-      <f:entry title="${%Exported variables}" field="additionalVariables">
-          <f:textarea/>
-          <f:description>Variables with macro support. *.prop file format</f:description>
-      </f:entry>
-      <f:entry title="${%Label-specific options}">
-          <f:repeatableProperty name="labelSpecifics" header="${%Label specific}" add="${%Add label}" var="labelSpecific" field="labelSpecifics">                                      
-          </f:repeatableProperty>
-      </f:entry>       
-      <f:optionalProperty
-          name="versioning" 
-          title="${%Enable Versions}" checked="${instance.hasVersions()}"
-          help="/plugin/custom-tools-plugin/CustomTool/help-versioning.html"
-          field="toolVersion">
-      </f:optionalProperty> 
+    <f:entry title="${%Exported paths}" field="exportedPaths">
+      <f:textbox/>
+    </f:entry>
+    <f:entry title="${%Installation directory}" field="home">
+      <f:textbox/>
+    </f:entry>
+    <f:entry title="${%Exported variables}" field="additionalVariables">
+      <f:textarea/>
+      <f:description>Variables with macro support. *.prop file format</f:description>
+    </f:entry>
+    <f:entry title="${%Label-specific options}">
+      <f:repeatableProperty name="labelSpecifics"
+                            field="labelSpecifics"
+                            header="${%Label specific}"
+                            add="${%Add label}"
+                            var="labelSpecific">
+      </f:repeatableProperty>
+    </f:entry>
+    <f:optionalProperty title="${%Enable Versions}"
+                        name="versioning"
+                        field="toolVersion"
+                        checked="${instance.hasVersions()}"
+                        help="/plugin/custom-tools-plugin/CustomTool/help-versioning.html">
+    </f:optionalProperty>
   </f:advanced>
- </j:jelly>
+</j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/customtools/CustomToolInstallWrapper/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/customtools/CustomToolInstallWrapper/config.jelly
@@ -1,38 +1,41 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:entry title="" description="">
-      <f:repeatable name="selectedTools" var="selectedTool" items="${instance.selectedTools}"
-        add="${%Add Tool}" header="Tools to install">
-         <j:set var="toolDescriptor" value="${descriptor}" /><!-- to make this descriptor accessible from properties -->
-        <table width="100%">
-           <f:entry title="${%Tool selection}">
-             <select class="setting-input" name="selectedTools.name">
-              <j:forEach var="installation" items="${descriptor.installations}">
-                <f:option selected="${installation.name==selectedTool.name}" 
-                          value="${installation.name}">${installation.name}</f:option>
-              </j:forEach>
-             </select>
-            <div align="right">
-              <f:repeatableDeleteButton value="${%Delete tool}"/>
-            </div>
-          </f:entry>
-        </table>        
-      </f:repeatable>      
-      <table width="100%">                
-          <f:optionalBlock name="multiconfigOptions" 
-                         title="${%Multi-configuration jobs specific parameters}" checked="${instance.hasMulticonfigOptions()}"
-                         help="/plugin/custom-tools-plugin/CustomToolInstallWrapper/help-multiconfigOptions.html">
-            <f:entry help="/plugin/custom-tools-plugin/CustomToolInstallWrapper/help-skipInstallationOnMaster.html">
-                 <f:checkbox title="Don't install tools at the master job" field="skipInstallationOnMaster" checked="${instance.multiconfigOptions.isSkipMasterInstallation()}"/>
-            </f:entry>
-        </f:optionalBlock> 
-      </table>
+    <f:repeatable name="selectedTools" var="selectedTool" items="${instance.selectedTools}"
+                  add="${%Add Tool}" header="Tools to install">
+      <j:set var="toolDescriptor" value="${descriptor}"/><!-- to make this descriptor accessible from properties -->
       <table width="100%">
-        <f:entry field="convertHomesToUppercase">
-          <f:checkbox title="${%Convert #ToolName_HOME variables to the upper-case}" checked="${instance.isConvertHomesToUppercase()}"/>
+        <f:entry title="${%Tool selection}">
+          <select class="setting-input" name="selectedTools.name">
+            <j:forEach var="installation" items="${descriptor.installations}">
+              <f:option selected="${installation.name==selectedTool.name}" value="${installation.name}">
+                ${installation.name}
+              </f:option>
+            </j:forEach>
+          </select>
+          <div align="right">
+            <f:repeatableDeleteButton value="${%Delete tool}"/>
+          </div>
         </f:entry>
       </table>
+    </f:repeatable>
+    <table width="100%">
+      <f:optionalBlock name="multiconfigOptions"
+                       title="${%Multi-configuration jobs specific parameters}"
+                       checked="${instance.hasMulticonfigOptions()}"
+                       help="/plugin/custom-tools-plugin/CustomToolInstallWrapper/help-multiconfigOptions.html">
+        <f:entry help="/plugin/custom-tools-plugin/CustomToolInstallWrapper/help-skipInstallationOnMaster.html">
+          <f:checkbox title="Don't install tools at the master job"
+                      field="skipInstallationOnMaster"
+                      checked="${instance.multiconfigOptions.isSkipMasterInstallation()}"/>
+        </f:entry>
+      </f:optionalBlock>
+    </table>
+    <table width="100%">
+      <f:entry field="convertHomesToUppercase">
+        <f:checkbox title="${%Convert #ToolName_HOME variables to the upper-case}"
+                    checked="${instance.isConvertHomesToUppercase()}"/>
+      </f:entry>
+    </table>
   </f:entry>
- 
 </j:jelly>

--- a/src/main/resources/com/synopsys/arc/jenkinsci/plugins/customtools/LabelSpecifics/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkinsci/plugins/customtools/LabelSpecifics/config.jelly
@@ -1,20 +1,17 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-           <!-- <table width="100%"> -->
-            <f:entry title="${%Label}" field="label">
-                <f:textbox/>  
-            </f:entry>
-            <f:entry title="${%Exported paths}" field="exportedPaths">
-                <f:textbox/>
-            </f:entry>        
-            <f:entry title="${%Additional variables}" field="additionalVars">
-                <f:textarea/>  
-            </f:entry>          
-            <f:entry title="">
-                <div align="right">
-                    <f:repeatableDeleteButton value="Remove..."/> 
-                </div>
-            </f:entry>
-           <!-- </table> -->       
-
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:entry title="${%Label}" field="label">
+    <f:textbox/>
+  </f:entry>
+  <f:entry title="${%Exported paths}" field="exportedPaths">
+    <f:textbox/>
+  </f:entry>
+  <f:entry title="${%Additional variables}" field="additionalVars">
+    <f:textarea/>
+  </f:entry>
+  <f:entry title="">
+    <div align="right">
+      <f:repeatableDeleteButton value="Remove..."/>
+    </div>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/com/synopsys/arc/jenkinsci/plugins/customtools/versions/ToolVersionConfig/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkinsci/plugins/customtools/versions/ToolVersionConfig/config.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:property field="versionsListSource"/>
 </j:jelly>

--- a/src/main/resources/com/synopsys/arc/jenkinsci/plugins/customtools/versions/ToolVersionParameterDefinition/config.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkinsci/plugins/customtools/versions/ToolVersionParameterDefinition/config.jelly
@@ -1,17 +1,16 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <f:entry title="${%Tool selection}">
-        
-        <j:invokeStatic var="possibleTools" 
-                        className="com.synopsys.arc.jenkinsci.plugins.customtools.versions.ToolVersionHelper"
-                        method="getAllVersionedTools"/>
-        <select class="setting-input" name="toolName">
-            <j:forEach var="installation" items="${possibleTools}">
-              <f:option selected="${installation.name==instance.toolName}" 
-                        value="${installation.name}">
-                            ${installation.name} (${installation.toolVersion.versionsListSource.name})
-              </f:option>
-            </j:forEach>
-        </select>
-     </f:entry>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:entry title="${%Tool selection}">
+    <j:invokeStatic var="possibleTools"
+                    className="com.synopsys.arc.jenkinsci.plugins.customtools.versions.ToolVersionHelper"
+                    method="getAllVersionedTools"/>
+    <select class="setting-input" name="toolName">
+      <j:forEach var="installation" items="${possibleTools}">
+        <f:option selected="${installation.name==instance.toolName}"
+                  value="${installation.name}">
+          ${installation.name} (${installation.toolVersion.versionsListSource.name})
+        </f:option>
+      </j:forEach>
+    </select>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/com/synopsys/arc/jenkinsci/plugins/customtools/versions/ToolVersionParameterDefinition/index.jelly
+++ b/src/main/resources/com/synopsys/arc/jenkinsci/plugins/customtools/versions/ToolVersionParameterDefinition/index.jelly
@@ -1,8 +1,6 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-  xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
-  xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-  <st:include class="com.cwctravel.hudson.plugins.extended_choice_parameter.ExtendedChoiceParameterDefinition" 
-              page="index.jelly"            
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+  <st:include class="com.cwctravel.hudson.plugins.extended_choice_parameter.ExtendedChoiceParameterDefinition"
+              page="index.jelly"
               it="${it.versionConfig.versionsListSource}"/>
 </j:jelly>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <div>
-  A generic tool installer. You define how tools get installed, and the plugin will automatically install them when needed. 
+  A generic tool installer. You define how tools get installed, and the plugin will automatically install them when needed.
 </div>


### PR DESCRIPTION
- consistent formatting
- remove unused XML namespaces

Due to fixing the indentation to see the actual changes it's advised to also have a look at this pull request with whitespace changes ignored.