### PR TITLE
JENKINS-60045 doesn`t fully implemented.

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/customtools/CustomTool.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/customtools/CustomTool.java
@@ -46,7 +46,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Arrays;
+import java.util.ArrayList;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import jenkins.MasterToSlaveFileCallable;
@@ -74,7 +74,7 @@ public class CustomTool extends ToolInstallation implements
     /**
      * Label-specific options.
      */
-    private final @CheckForNull LabelSpecifics[] labelSpecifics;
+    private @CheckForNull ArrayList<LabelSpecifics> labelSpecifics;
     /**
      * A cached value of the home directory.
      */
@@ -89,16 +89,18 @@ public class CustomTool extends ToolInstallation implements
      */
     private final @CheckForNull String additionalVariables;
 
-    private static final LabelSpecifics[] EMPTY_LABELS = new LabelSpecifics[0];
+    private static final @Nonnull ArrayList<LabelSpecifics> EMPTY_LABELS = new ArrayList<LabelSpecifics>();
 
     @DataBoundConstructor
     public CustomTool(@Nonnull String name, @Nonnull String home,
-            @CheckForNull List<? extends ToolProperty<?>> properties, @CheckForNull String exportedPaths,
-            @CheckForNull LabelSpecifics[] labelSpecifics, @CheckForNull ToolVersionConfig toolVersion,
-            @CheckForNull String additionalVariables) {
+                      @CheckForNull List<? extends ToolProperty<?>> properties,
+                      @CheckForNull String exportedPaths,
+                      @CheckForNull ArrayList<LabelSpecifics> labelSpecifics,
+                      @CheckForNull ToolVersionConfig toolVersion,
+                      @CheckForNull String additionalVariables) {
         super(name, home, properties);
         this.exportedPaths = exportedPaths;
-        this.labelSpecifics = labelSpecifics != null ? Arrays.copyOf(labelSpecifics, labelSpecifics.length) : null;
+        this.labelSpecifics = (labelSpecifics != null) ? new ArrayList<LabelSpecifics>(labelSpecifics) : EMPTY_LABELS;
         this.toolVersion = toolVersion;
         this.additionalVariables = additionalVariables;
     }
@@ -129,8 +131,8 @@ public class CustomTool extends ToolInstallation implements
         correctedHome = pathList.getHomeDir();
     }
 
-    public @Nonnull LabelSpecifics[] getLabelSpecifics() {
-        return (labelSpecifics!=null) ? labelSpecifics : EMPTY_LABELS;
+    public @Nonnull ArrayList<LabelSpecifics> getLabelSpecifics() {
+        return (labelSpecifics !=null) ? labelSpecifics : EMPTY_LABELS;
     }
 
     /**

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/customtools/LabelSpecifics.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/customtools/LabelSpecifics.java
@@ -23,6 +23,7 @@ import hudson.model.Descriptor;
 import hudson.model.Label;
 import hudson.model.Node;
 import java.io.Serializable;
+import java.util.ArrayList;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
@@ -105,6 +106,24 @@ public class LabelSpecifics extends AbstractDescribableImpl<LabelSpecifics> impl
         }
         return out;
     }
+
+    public static @Nonnull
+    ArrayList<LabelSpecifics> substitute (ArrayList<LabelSpecifics> specifics, @Nonnull EnvVars vars) {
+        ArrayList<LabelSpecifics> out = new ArrayList<LabelSpecifics>();
+        for (int i=0; i<specifics.size(); i++) {
+            out.add(specifics.get(i).substitute(vars));
+        }
+        return out;
+    }
+
+    public static @Nonnull ArrayList<LabelSpecifics> substitute (ArrayList<LabelSpecifics> specifics, Node node) {
+        ArrayList<LabelSpecifics> out = new ArrayList<LabelSpecifics>();
+        for (int i=0; i<specifics.size(); i++) {
+            out.add(specifics.get(i).substitute(node));
+        }
+        return out;
+    }
+
 
     @Extension
     public static class DescriptorImpl extends Descriptor<LabelSpecifics> {


### PR DESCRIPTION
Original issue is that JCasC could create jenkins.yaml for customTool section. It happened, because, io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator.describe(DataBoundConfigurator.java:299) could work with Arrays.
It was fixed with https://github.com/jenkinsci/configuration-as-code-plugin/pull/1234/
. Now it is possible to create quite correct jenkins.yaml, but Jinkins can`t be started it. JENKINS-60976.

This fix replaces array to list provide opportunity to create yaml and configure Jenkins.

Previous pull request could be deleted. Sorry for mess.