### PR TITLE
JENKINS-60976 - Make the `home` field optional when defining tools via Configuration-as-Code

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/customtools/CustomTool.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/customtools/CustomTool.java
@@ -92,7 +92,7 @@ public class CustomTool extends ToolInstallation implements
     private static final LabelSpecifics[] EMPTY_LABELS = new LabelSpecifics[0];
 
     @DataBoundConstructor
-    public CustomTool(@CheckForNull String name, @CheckForNull String home,
+    public CustomTool(@Nonnull String name, @CheckForNull String home,
             @CheckForNull List<? extends ToolProperty<?>> properties, @CheckForNull String exportedPaths,
             @CheckForNull LabelSpecifics[] labelSpecifics, @CheckForNull ToolVersionConfig toolVersion,
             @CheckForNull String additionalVariables) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/customtools/CustomTool.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/customtools/CustomTool.java
@@ -92,7 +92,7 @@ public class CustomTool extends ToolInstallation implements
     private static final LabelSpecifics[] EMPTY_LABELS = new LabelSpecifics[0];
 
     @DataBoundConstructor
-    public CustomTool(@Nonnull String name, @Nonnull String home,
+    public CustomTool(@CheckForNull String name, @CheckForNull String home,
             @CheckForNull List<? extends ToolProperty<?>> properties, @CheckForNull String exportedPaths,
             @CheckForNull LabelSpecifics[] labelSpecifics, @CheckForNull ToolVersionConfig toolVersion,
             @CheckForNull String additionalVariables) {


### PR DESCRIPTION
As per suggestion by @timja  - fix for [JENKINS-60976 ](https://issues.jenkins-ci.org/browse/JENKINS-60976 ) to make this plugin work with JCasC