### PR TITLE
[JENKINS-37389] add @Symbol("custom") to CustomTool's descriptor

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/customtools/CustomTool.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/customtools/CustomTool.java
@@ -53,6 +53,7 @@ import javax.annotation.Nonnull;
 import jenkins.MasterToSlaveFileCallable;
 import jenkins.plugins.customtools.util.envvars.VariablesSubstitutionHelper;
 
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -211,6 +212,7 @@ public class CustomTool extends ToolInstallation implements
     }
 
     @Extension
+    @Symbol("custom")
     public static class DescriptorImpl extends ToolDescriptor<CustomTool> {
 
         public DescriptorImpl() {


### PR DESCRIPTION
The `@Symbol` annotation defines a unique identifier which is used by DSL. Whit this commit it is possible to distinguish a difference between tools when the the `tool` step is called. Example:
* tool name: 'myTool', type: 'jdk' ← returns JDK with id "myTool"
* tool name: 'myTool', type: 'custom' ← returns custom tool with id "myTool"

Addresses [JENKINS-37389 Add @Symbol("custom") to Custom Tool's ToolDescriptor](https://issues.jenkins.io/browse/JENKINS-37389).

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

I didn't add any tests. Every extension should be annotated with `@Symbol`. Its value must be unique within a specific extension point, and there are no other tools with `custom` identifier (the change is safe).

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
