### PR TITLE
Modernize to latest versions supported by Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,8 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.16</version>
+    <version>4.51</version>
+    <relativePath/>
   </parent>
 
   <groupId>com.cloudbees.jenkins.plugins</groupId>
@@ -44,18 +45,16 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.222.4</jenkins.version>
-    <java.level>8</java.level>
+    <jenkins.version>2.346.3</jenkins.version>
   </properties>
-
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.222.x</artifactId>
-        <version>26</version>
-        <scope>import</scope>
+        <artifactId>bom-2.346.x</artifactId>
+        <version>1763.v092b_8980a_f5e</version>
         <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/main/java/com/cloudbees/jenkins/plugins/customtools/CustomToolInstallWrapper.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/customtools/CustomToolInstallWrapper.java
@@ -221,6 +221,7 @@ public class CustomToolInstallWrapper extends BuildWrapper {
 
         return new Launcher.DecoratedLauncher(launcher) {
             @Override
+            @SuppressFBWarnings("DCN_NULLPOINTER_EXCEPTION")
             public Proc launch(ProcStarter starter) throws IOException {
                 EnvVars vars;
                 try { // Dirty hack, which allows to avoid NPEs in Launcher::envs()


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Hi @oleg-nenashev!

This PR aims to modernize tooling and move this plugin closer to the [recommended Jenkins baseline version](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/) without making the change too big. If this goes well, I can follow up with a subsequent PR to modernize further.

Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.jenkins.ModernizePluginForJava8

### Testing done

Ran `mvn clean verify`. The new tooling picked up an existing SpotBugs issue, but after seeing the comments I decided to suppress this instance because it's clearly intentional.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

Fixes #62.